### PR TITLE
Update keyboard remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,15 +172,12 @@ Here are the steps to go from chromeOS to macOS via OpenCore on your Chromebook.
 5. If you haven't already, add `igfxrpsc=1` and `-igfxnotelemetryload` to your `boot-args`, under `NVRAM -> Add -> 7C436110-AB2A-4BBB-A880-FE41995C9F82,`. Both are for iGPU support, **you will regret it if you don't add these.**
 6. **Set your SMBIOS as MacBookAir8,1**. Ignore what the guide tells you to use, MacBookAir8,1 works better with our laptop.
      > **Note** If you choose to use `MacBook10,1`, which also works, you will not have Low Battery Mode.
-7. Switch the VoodoolPS2 from acidanthera with this [custom build that's designed for Chromebooks](https://github.com/one8three/VoodooPS2-Chromebook/releases) for keyboard backlight control + custom remaps. 
-   - Keyboard backlight SSDT (`SSDT-KBBL.aml`) can be found [here](https://github.com/one8three/VoodooPS2-Chromebook/blob/master/SSDT-KBBL.aml). Drag it to your ACPI folder.
-     > **Note**: This SSDT only works with the custom VoodoolPS2 linked above.
-8. Download [EmeraldSDHC](https://github.com/acidanthera/EmeraldSDHC/releases) for eMMC storage support. Put it in your Kexts folder. 
-9. Download corpnewt's SSDTTime, then launch it and select `FixHPET` as the first option. Next, select `'C'` for the default setting, and drag the SSDT it generated (`SSDT-HPET.aml`) into your `ACPI` folder. Finally, copy the patches from `oc_patches.plist` into your `config.plist` under `ACPI -> Patch`. This is to ensure eMMC storage is recognized my macOS.
-10. Map your USB ports³ before installing ~~to prevent dead hard drives, thermonuclear war, or you getting fired.~~ See [Misc. Information](#misc-information) for a note to USBToolBox users.    
-12. Using corpnewt's SSDTTime, dump your DSDT, generate `SSDT-USB-RESET.aml`, drag it to your ACPI folder, and reload your `config.plist`. **Required** for working USB ports.
-13. Snapshot (cmd +r) or (ctrl + r) your `config.plist`. 
-14. Install macOS and enjoy!
+7. Download [EmeraldSDHC](https://github.com/acidanthera/EmeraldSDHC/releases) for eMMC storage support. Put it in your Kexts folder. 
+8. Download corpnewt's SSDTTime, then launch it and select `FixHPET` as the first option. Next, select `'C'` for the default setting, and drag the SSDT it generated (`SSDT-HPET.aml`) into your `ACPI` folder. Finally, copy the patches from `oc_patches.plist` into your `config.plist` under `ACPI -> Patch`. This is to ensure eMMC storage is recognized my macOS.
+9. Map your USB ports³ before installing ~~to prevent dead hard drives, thermonuclear war, or you getting fired.~~ See [Misc. Information](#misc-information) for a note to USBToolBox users.    
+10. Using corpnewt's SSDTTime, dump your DSDT, generate `SSDT-USB-RESET.aml`, drag it to your ACPI folder, and reload your `config.plist`. **Required** for working USB ports.
+11. Snapshot (cmd +r) or (ctrl + r) your `config.plist`. 
+12. Install macOS and enjoy!
 
 > **Note**: More information about specific quirks can be found [here.](https://dortania.github.io/docs/latest/Configuration.html)
 
@@ -228,6 +225,16 @@ SSDT-USB-Reset.aml aka. SSDT-RHUB.aml
 ### Security 
 - Please read [Security.md](SECURITY.md) as it provides in-depth information on sanitizing your serials, disk encryption, and more.
 - **If you discover a vulnerability, please refer to [Security.md](SECURITY.md).** 
+
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+
+### Keyboard Remapping
+
+1. Download the custom remap SSDT
+2. 
+
+
+
 
 --------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Turns out, this laptop works really well with the latest version(s) of macOS. Fo
 | Trackpad           | Working              | With `VoodooI2C.kext` and `VoodooI2CELAN.kext`.                                               | 
 | Graphics Accel.    | Working              | With `-igfxnotelemetryload` in the `boot-args`.                                               |
 | Internal Speakers  | Not working          | Unsupported codec. (`max98927`)                                                               |
-| Keyboard backlight | Working              | With `SSDT-KBBl.aml` _**and**_ the custom `VoodoolPS2.kext`.                                  |           
-| Keyboard & Remaps  | Working              | With the custom `VoodoolPS2.kext`.                                                            |
+| Keyboard backlight | Working              | With custom SSDT patching.                                                                    |           
+| Keyboard & Remaps  | Working              | With custom SSDT patching.                                                                    |
 | eMMC Storage       | Working              | With `EmeraldSDHC.kext`and IRQ patching (with SSDTTime)                                       |    
 | SD Card Reader     | Not working          | Coming soon with `EmeraldSDHC.kext`.                                                          |
-| Headphone Jack     | Not working          | Unsupported codec
+| Headphone Jack     | Not working          | Unsupported codec                                                                             |
 | USB Ports          | Working              | Working with USB mapping **and** `SSDT-USB-RESET.aml`                                         |
 | Webcam             | Working              | Working OOTB                                                                                  |
 | Internal Mic.      | Not working          | Same reason why internal speakers don't work; unsupported codec. (`max98927`)                 |
@@ -72,8 +72,26 @@ Turns out, this laptop works really well with the latest version(s) of macOS. Fo
 | Shutdown / Restart | Working              | Working with `ProtectMemoryReigons` enabled in `config.plist`.                                |    
 | Recovery Combos    | Working              | Working OOTB with coreboot.                                                                   |
 | Continuity         | Not Working          | Limitation with Intel WiFI cards / `itlwm`.                                                   |                                                                             
-                                                                                    
 --------------------------------------------------------------------------------------------------------------------------------------------------------
+
+### Specs
+
+- CPU: Intel m3-8100Y /i5-8200Y 
+- IGPU: Intel UHD 615
+- RAM: 4GB / 8GB 1867MHz LPDDR3
+- STORAGE: 128GB / 64GB / 32GB eMMC
+- WLAN: Intel Wireless 7265
+- KEYBOARD: PS2
+- TRACKPAD: ELAN I2C
+- MICROPHONE: DMIC DA7219
+- SPEAKERS: INTEL DSP MAX98927
+
+
+> **Note**: Mic, headphone jack, and internal speakers all do not work with macOS. 
+Unless you want to write drivers for us ;)
+
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+
 ### Versions Tested
 
 #### macOS:
@@ -280,7 +298,6 @@ for those that want to install neofetch but don't want to download Xcode / homeb
   - More info here: [cdn.discordapp.com](https://cdn.discordapp.com/attachments/1051619981642706947/1077064200490324019/image.png)
 - Base HD Audio driver for Skylake and up. Used for HDMI Audio support on Windows.
   - [github.com/coolstar/sklhdaudbus](https://github.com/coolstar/sklhdaudbus)
-- DMIC uses DA7219 as the mic array, max98927 as the audio codec.
 
 --------------------------------------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This replaces the old VoodooPS2-Chromebook with an SSDT.
This SSDT is intended to function the same way as the custom VoodooPS2 fork, even on the newest versions of VoodooPS2.

Making this a draft because there are still things to figure out, i.e how to add keyboard backlight to it and finding the correct ACPI path.